### PR TITLE
[SET-308] Fix pr-merge failed when github owner contains repository name

### DIFF
--- a/pr-merge
+++ b/pr-merge
@@ -86,7 +86,7 @@ fi
 readonly URL_PARSE=$(echo "${FETCH_URL}" | sed "s/\//:/g")
 readonly REPO_PART="${URL_PARSE##*:}"
 readonly REPO=$(echo "${REPO_PART}" | sed "s/.git//")
-readonly URL_LEFT=$(echo "${URL_PARSE}" | sed "s/:${REPO_PART}//")
+readonly URL_LEFT="${URL_PARSE:0:$((${#URL_PARSE} - ${#REPO_PART} - 1))}"
 readonly OWNER="${URL_LEFT##*:}"
 
 if [ -z "${OWNER}" -o -z "${REPO}" ]; then


### PR DESCRIPTION
Issue: SET-308

`pr-merge` failed to parse github owner in case it contains repository name, like: `https://github.com/undertow-io/undertow`